### PR TITLE
add <c-p> and <c-n> keymapping

### DIFF
--- a/plugin/vimcalc.vim
+++ b/plugin/vimcalc.vim
@@ -117,6 +117,8 @@ function! s:VCalc_DefineMappingsAndAutoCommands()
 
     imap <buffer> <silent> <up> <C-o>:call <SID>VCalc_PreviousHistory()<CR>
     imap <buffer> <silent> <down> <C-o>:call <SID>VCalc_NextHistory()<CR>
+    imap <buffer> <silent> <c-p> <C-o>:call <SID>VCalc_PreviousHistory()<CR>
+    imap <buffer> <silent> <c-n> <C-o>:call <SID>VCalc_NextHistory()<CR>
 
     au BufEnter <buffer> :call <SID>VCalc_InsertOnEnter()
 


### PR DESCRIPTION
We always use ctrl-p and ctrl-n to browse history of cmd